### PR TITLE
add_openglwidgets_to_linux

### DIFF
--- a/src/Sample/Sample.pro
+++ b/src/Sample/Sample.pro
@@ -33,6 +33,7 @@ linux-g++* {
     }
 
     DEFINES += CSM_TARGET_LINUX_GL
+    QT += openglwidgets
 }
 
 win32-msvc*{


### PR DESCRIPTION
Add `QT += openglwidgets` for Linux  g++ compiler in `Sample.pro` so that it can find QOpenGLWidget.h.